### PR TITLE
Improve stub-searching performance

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/StubResolver.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/StubResolver.scala
@@ -52,7 +52,7 @@ final class StubResolver(stubDAO: HttpStubDAO[Task], stateDAO: PersistentStateDA
           )
         )
         condition0 = prop[HttpStub](_.method) === method &&
-          (prop[HttpStub](_.path) ==@ path || pathPatternExpr) &&
+          (prop[HttpStub](_.path) ==@ path || (prop[HttpStub](_.path).notExists && pathPatternExpr)) &&
           prop[HttpStub](_.scope) === scope
         condition = (scope == Scope.Countdown).fold(condition0 && prop[HttpStub](_.times) > Option(0), condition0)
         candidates0 <- stubDAO.findChunk(condition, 0, Int.MaxValue)

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/dal/HttpStubDAO.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/dal/HttpStubDAO.scala
@@ -6,8 +6,6 @@ import cats.tagless.autoFunctorK
 import com.github.dwickern.macros.NameOf.*
 import org.mongodb.scala.MongoCollection
 import org.mongodb.scala.bson.BsonDocument
-import org.mongodb.scala.model.Filters.exists
-import org.mongodb.scala.model.IndexOptions
 import org.mongodb.scala.model.Indexes.*
 import simulacrum.typeclass
 
@@ -66,11 +64,12 @@ class HttpStubDAOImpl(collection: MongoCollection[BsonDocument])
     with HttpStubDAO[Task] {
   def createIndexes: Task[Unit] =
     createIndex(
-      ascending(nameOf[HttpStub](_.method), nameOf[HttpStub](_.path), nameOf[HttpStub](_.scope)),
-      IndexOptions().partialFilterExpression(exists(nameOf[HttpStub](_.path)))
-    ) *> createIndex(
-      ascending(nameOf[HttpStub](_.method), nameOf[HttpStub](_.pathPattern), nameOf[HttpStub](_.scope)),
-      IndexOptions().partialFilterExpression(exists(nameOf[HttpStub](_.pathPattern)))
+      ascending(
+        nameOf[HttpStub](_.method),
+        nameOf[HttpStub](_.path),
+        nameOf[HttpStub](_.scope),
+        nameOf[HttpStub](_.times)
+      ),
     ) *> createIndex(
       descending(nameOf[HttpStub](_.created))
     ) *> createIndex(

--- a/backend/project/Settings.scala
+++ b/backend/project/Settings.scala
@@ -26,8 +26,8 @@ object Settings {
 
   val common = Seq(
     organization := "ru.tinkoff",
-    version := "3.11.1",
-    scalaVersion := "2.13.11",
+    version := "3.11.2",
+    scalaVersion := "2.13.12",
     Compile / packageDoc / publishArtifact := false,
     Compile / packageSrc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,

--- a/backend/project/build.properties
+++ b/backend/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.5
+sbt.version = 1.9.6


### PR DESCRIPTION
$regexMatch inside $expr couldn't effectively use indexes. This PR introduces alternative approach - only documents without path are taken in account