### PR TITLE
Proposal: add logging of request from proxy stub for debugging purposes. 

### DIFF
--- a/backend/mockingbird/src/main/resources/application.conf
+++ b/backend/mockingbird/src/main/resources/application.conf
@@ -27,6 +27,7 @@ ru.tinkoff.tcb {
     excludedRequestHeaders = []
     excludedResponseHeaders = []
     insecureHosts = []
+    logOutgoingRequests = false
   }
 
   event {

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/config/Configuration.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/config/Configuration.scala
@@ -32,7 +32,8 @@ case class ProxyConfig(
     excludedRequestHeaders: Seq[String],
     excludedResponseHeaders: Set[String],
     proxyServer: Option[ProxyServerConfig],
-    insecureHosts: Seq[String]
+    insecureHosts: Seq[String],
+    logOutgoingRequests: Boolean
 )
 
 case class EventConfig(fetchInterval: FiniteDuration, reloadInterval: FiniteDuration)

--- a/configuration.md
+++ b/configuration.md
@@ -23,6 +23,7 @@ Mockingbird конфигурируется посредством файла sec
       "excludedRequestHeaders": [..],
       "excludedResponseHeaders": [..],
       "insecureHosts": [..],
+      "logOutgoingRequests": false,
       "proxyServer": {
         "type": "http" | "socks",
         "type": "..",
@@ -87,14 +88,17 @@ healthCheckRoute - необязательный параметр, позволя
       "excludedResponseHeaders": ["transfer-encoding"],
       "insecureHosts": [
         "some.host"
-      ]
+      ],
+      "logOutgoingRequests": false
     }
   }
 }
 ```
 
 В поле insecureHosts можно указать список хостов, для которых не будет выполняться проверка сертификатов. Это может быть полезно
-для случаев развёртывания во внутренней инфраструктуре
+для случаев развёртывания во внутренней инфраструктуре.
+
+Флаг logOutgoingRequests позволяет включить логирование запросов к удаленному серверу, когда http заглушка работет в режиме прокси. Запрос пишется в лог в виде команды curl с заголовками и телом запроса.
 
 Так-же в этой секции можно указать настройки прокси сервера. Эти настройки влияют на ВСЕ http запросы, которые делаем mockingbird, т.е.:
 - запросы к внешнему серверу с proxy моках


### PR DESCRIPTION
It's pretty hard to understand what request will be executed from mockingbird to a remote server, when stub works in proxy mode. The logging of requests simplifies understanding what happens. It's not necessary, but could be useful.

The PR add to the log the following records:
```
{"@timestamp":"2023-09-30T20:11:48.776Z","loggerName":"ru.tinkoff.tcb.mockingbird.api.PublicApiHandler","threadName":"ZScheduler-2","level":"DEBUG","message":"Executing request: curl \\\n  --request GET \\\n  --url 'https://catfact.ninja/fact' \\\n  --header 'Host: catfact.ninja' \\\n  --header 'User-Agent: curl/7.88.1' \\\n  --header 'Accept: */*' \\\n  --location \\\n  --max-redirs 32","correlationId":"ee779037-c036-465b-9ac8-46987bb3a7be","payload":{"path":"/alpha/fact","method":"GET","name":"cats fact"}}
```