### PR TITLE
Fix/grpc stub

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
@@ -436,7 +436,8 @@ final class AdminApiHandler(
       candidates = candidates0
         .filter(_.requestClass == body.requestClass)
         .filter(_.requestSchema == requestSchema)
-        .filter(_.requestPredicates.definition == body.state)
+        .filter(_.requestPredicates.definition == body.requestPredicates.definition)
+        .filter(_.state == body.state)
       _ <- ZIO.when(candidates.nonEmpty)(
         ZIO.fail(
           DuplicationError("Существует заглушка(-ки), полностью совпадающая по условиям и типу", candidates.map(_.id))

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
@@ -425,8 +425,9 @@ final class AdminApiHandler(
         )
       )
       requestSchema <- protobufSchemaResolver.parseDefinitionFrom(requestSchemaBytes)
+      rootFields    <- GrpcStub.getRootFields(body.requestClass, requestSchema)
       _ <- ZIO.foreachParDiscard(body.requestPredicates.definition.keys)(
-        GrpcStub.validateOptics(_, body.requestClass, requestSchema)
+        GrpcStub.validateOptics(_, requestSchema, rootFields)
       )
       candidates0 <- grpcStubDAO.findChunk(
         prop[GrpcStub](_.methodName) === body.methodName,
@@ -444,6 +445,7 @@ final class AdminApiHandler(
         )
       )
       responseSchema <- protobufSchemaResolver.parseDefinitionFrom(responseSchemaBytes)
+      _              <- GrpcStub.getRootFields(body.responseClass, responseSchema)
       now            <- ZIO.clockWith(_.instant)
       stub = body
         .into[GrpcStub]

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcExractor.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcExractor.scala
@@ -110,7 +110,7 @@ object GrpcExractor {
     def convertMessageToJson(bytes: Array[Byte], className: String): Task[Json] =
       ZIO.fromEither {
         val message    = parseFrom(bytes, className)
-        val jsonString = JsonFormat.printer().print(message)
+        val jsonString = JsonFormat.printer().preservingProtoFieldNames().print(message)
         parse(jsonString)
       }
   }

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcExractor.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcExractor.scala
@@ -108,11 +108,11 @@ object GrpcExractor {
     }
 
     def convertMessageToJson(bytes: Array[Byte], className: String): Task[Json] =
-      ZIO.fromEither {
-        val message    = parseFrom(bytes, className)
-        val jsonString = JsonFormat.printer().preservingProtoFieldNames().print(message)
-        parse(jsonString)
-      }
+      for {
+        message    <- ZIO.attempt(parseFrom(bytes, className))
+        jsonString <- ZIO.attempt(JsonFormat.printer().preservingProtoFieldNames().print(message))
+        js         <- ZIO.fromEither(parse(jsonString))
+      } yield js
   }
 
   implicit class FromDynamicSchema(private val dynamicSchema: DynamicSchema) extends AnyVal {


### PR DESCRIPTION
### Problem

1. Possibility to create identical gRPC stubs. Because the checking doesn't work.
2. Matching gRPC request body with predicate doesn't work. The reason is protobuf by default serializes message as a JSON with lowerCamelCase, but the predicate refers to fields as they are set inside proto-file, usually it is snake_case.
3. The validation of schemes, that they contain request/response classes, is run only if the stub contains request predicate. 

### Solution

1. Fix comparing fields of gRPC stubs.
2. Using protobuf JSON printer that keeps field names as they are inside proto-file.
3. Run validation regardless the stub contains request predicate or not.


### Steps to reproduce bugs

Suppose that all stubs use the following proto-file with name "nested.proto": 
```
syntax = "proto3";

package utp.stock_service.v1;

message GetStocksRequest {
  repeated string offer_codes = 1;
  int32 offset = 2;
  int32 limit = 3 ;
}

message GetStocksResponse {
  message Stock {
    int64 quantity = 1;
    string name = 2;
  }
  repeated Stock stocks = 1;
}

service StockService {
  rpc GetStocks1(GetStocksRequest) returns (GetStocksResponse);
  rpc GetStocks2(GetStocksRequest) returns (GetStocksResponse);
  rpc GetStocks3(GetStocksRequest) returns (GetStocksResponse);
}
```

And also, there is service "alpha". For creating the service, one can run the command:
```
curl -X POST -d '{"suffix":"alpha", "name":"alpha"}' http://127.0.0.1:8228/api/internal/mockingbird/v2/service
```

#### 1.  Possibility to create identical gRPC stubs. Because the checking doesn't work.

Simple twice run this command:

```
curl \
  --request POST \
  --url 'http://127.0.0.1:8228/api/internal/mockingbird/v2/grpcStub' \
  --data '{
  "name": "Test gRPC",
  "scope": "persistent",
  "times": 1,
  "service": "alpha",
  "requestCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXF1ZXN0IHsKICByZXBlYXRlZCBzdHJpbmcgb2ZmZXJfY29kZXMgPSAxOwogIGludDMyIG9mZnNldCA9IDI7CiAgaW50MzIgbGltaXQgPSAzIDsKfQo=",
  "requestClass": "utp.stock_service.v1.GetStocksRequest",
  "requestPredicates": {},
  "responseCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXNwb25zZSB7CiAgbWVzc2FnZSBTdG9jayB7CiAgICBpbnQ2NCBxdWFudGl0eSA9IDE7CiAgICBzdHJpbmcgbmFtZSA9IDI7CiAgfQogIHJlcGVhdGVkIFN0b2NrIHN0b2NrcyA9IDE7Cn0K",
  "responseClass": "utp.stock_service.v1.GetStocksResponse",
  "response": {
    "data": {
      "stocks": [
        {"name": "TNKF", "quantity": 578}
      ]
    },
    "mode": "fill"
  },
  "methodName": "utp.stock_service.v1.StockService/GetStocks1"
}'
```

Expectation is the second run fails because the same stub exists. Reality is, the second run completes successfully. And if one try to call this stub, Mockingbird returns an error.

#### 2. Matching gRPC request body with predicate doesn't work.

Create a new gRPC stub with adding `requestPredicates` to the previous stub:

```
curl \
  --request POST \
  --url 'http://127.0.0.1:8228/api/internal/mockingbird/v2/grpcStub' \
  --data '{
  "name": "Test gRPC",
  "scope": "persistent",
  "times": 1,
  "service": "alpha",
  "requestCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXF1ZXN0IHsKICByZXBlYXRlZCBzdHJpbmcgb2ZmZXJfY29kZXMgPSAxOwogIGludDMyIG9mZnNldCA9IDI7CiAgaW50MzIgbGltaXQgPSAzIDsKfQo=",
  "requestClass": "GetStocksRequest",
  "requestPredicates": {
    "offer_codes.[0]": {"==": "ARVL"}
  },
  "responseCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXNwb25zZSB7CiAgbWVzc2FnZSBTdG9jayB7CiAgICBpbnQ2NCBxdWFudGl0eSA9IDE7CiAgICBzdHJpbmcgbmFtZSA9IDI7CiAgfQogIHJlcGVhdGVkIFN0b2NrIHN0b2NrcyA9IDE7Cn0K",
  "responseClass": "utp.stock_service.v1.GetStocksResponse",
  "response": {
    "data": {
      "stocks": [
        {"name": "ARVL", "quantity": 123}
      ]
    },
    "mode": "fill"
  },
  "methodName": "utp.stock_service.v1.StockService/GetStocks2"
}'
```

Then, send a gRPC request likes this:

```
grpcurl \
  -proto nested.proto \
  -d '{"offer_codes": ["ARVL"], "offset": 1, "limit": -1}' \
  -plaintext 127.0.0.1:9000 \
  "utp.stock_service.v1.StockService/GetStocks2"
```

Expectation is Mockingbird returns answer:

```
{
  "stocks": [
    {
      "quantity": "123",
      "name": "ARVL"
    }
  ]
}
```

Reality is Mockingbird returns an error.

#### 3. The validation of schemes, that they contain request/response classes, is run only if the stub contains request predicate.

Try to create gRPC stub with the following command:

```
curl \
  --request POST \
  --url 'http://127.0.0.1:8228/api/internal/mockingbird/v2/grpcStub' \
  --data '{
  "name": "Test gRPC",
  "scope": "persistent",
  "times": 1,
  "service": "alpha",
  "requestCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXF1ZXN0IHsKICByZXBlYXRlZCBzdHJpbmcgb2ZmZXJfY29kZXMgPSAxOwogIGludDMyIG9mZnNldCA9IDI7CiAgaW50MzIgbGltaXQgPSAzIDsKfQo=",
  "requestClass": "NON_EXISTENT_REQUEST",
  "requestPredicates": {},
  "responseCodecs": "c3ludGF4ID0gInByb3RvMyI7CgpwYWNrYWdlIHV0cC5zdG9ja19zZXJ2aWNlLnYxOwoKbWVzc2FnZSBHZXRTdG9ja3NSZXNwb25zZSB7CiAgbWVzc2FnZSBTdG9jayB7CiAgICBpbnQ2NCBxdWFudGl0eSA9IDE7CiAgICBzdHJpbmcgbmFtZSA9IDI7CiAgfQogIHJlcGVhdGVkIFN0b2NrIHN0b2NrcyA9IDE7Cn0K",
  "responseClass": "NON_EXISTENT_RESPONSE",
  "response": {
    "data": {
      "stocks": [
        {"name": "TNKF", "quantity": 587}
      ]
    },
    "mode": "fill"
  },
  "methodName": "utp.stock_service.v1.StockService/GetStocks3"
}'
```

Expectation is Mockingbird returns an error, because the proto scheme doesn't contain specified classes. Reality is, the stub is created. Attempt to call this stub fails with error.

@mockingbird/maintainers
