### PR TITLE
fix: Creating stub with XPath inside request condition fails

### DIFF
--- a/backend/mockingbird-native/src/main/resources/META-INF/native-image/ru.tinkoff.tcb/mockingbird/reflect-config.json
+++ b/backend/mockingbird-native/src/main/resources/META-INF/native-image/ru.tinkoff.tcb/mockingbird/reflect-config.json
@@ -2826,5 +2826,9 @@
         ]
       }
     ]
+  },
+  {
+    "name": "com.sun.org.apache.xpath.internal.functions.FuncLocalPart",
+    "methods" : [{"name":"<init>","parameterTypes":[] }]
   }
 ]


### PR DESCRIPTION
It fixes the case when a stub inside request condition contains XPath with a function, for example:

    "request": {
      "mode": "xpath",
      "headers": {},
      "body": {
        "//*[local-name() = \"BaggageOptionCode\"]": {"exists": true}
      }
    }

@mockingbird/maintainers
