### PR TITLE
Fix calling gRPC stub if proto-scheme contains nested enum

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcSchema.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcSchema.scala
@@ -105,7 +105,8 @@ case class GrpcMessageSchema(
     name: String,
     fields: List[GrpcField],
     oneofs: Option[List[GrpcOneOfSchema]] = None,
-    nested: Option[List[GrpcMessageSchema]] = None
+    nested: Option[List[GrpcMessageSchema]] = None,
+    nestedEnums: Option[List[GrpcEnumSchema]] = None,
 ) extends GrpcRootMessage
 
 object GrpcMessageSchema {

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcStub.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcStub.scala
@@ -55,7 +55,7 @@ object GrpcStub {
         definition.schemas.find(_.name == name)
       )
       rootFields <- rootMessage match {
-        case GrpcMessageSchema(_, fields, oneofs, _) =>
+        case GrpcMessageSchema(_, fields, oneofs, _, _) =>
           ZIO.succeed(fields ++ oneofs.map(_.flatMap(_.options)).getOrElse(List.empty))
         case GrpcEnumSchema(_, _) =>
           ZIO.fail(ValidationError(Vector(s"Enum cannot be a root message, but '$className' is")))
@@ -85,7 +85,7 @@ object GrpcStub {
               definition.schemas.find(_.name == field.typeName) match {
                 case Some(message) =>
                   message match {
-                    case GrpcMessageSchema(_, fs, oneofs, _) =>
+                    case GrpcMessageSchema(_, fs, oneofs, _, _) =>
                       fields.set(fs ++ oneofs.map(_.flatMap(_.options)).getOrElse(List.empty))
                     case GrpcEnumSchema(_, _) => fields.set(List.empty)
                   }

--- a/backend/mockingbird/src/test/resources/nested.proto
+++ b/backend/mockingbird/src/test/resources/nested.proto
@@ -9,6 +9,13 @@ message GetStocksRequest {
 }
 
 message GetStocksResponse {
+  enum StockKinds {
+    SK_UNKNOWN = 0;
+    SK_GROWTH = 1;
+    SK_INCOME = 2;
+    SK_VALUE = 3;
+    SK_BLUE_CHIP = 4;
+  }
   message Stock {
     int64 quantity = 1;
     string name = 2;

--- a/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/MappersSpec.scala
+++ b/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/MappersSpec.scala
@@ -1,90 +1,79 @@
 package ru.tinkoff.tcb.protobuf
 
-import java.io.File
-import java.io.FileInputStream
-import java.nio.file.Files
-import java.nio.file.Paths
-import scala.language.postfixOps
-import scala.reflect.io.Directory
-import scala.sys.process.*
-
 import com.github.os72.protobuf.dynamic.DynamicSchema
-import zio.managed.*
 import zio.test.*
 
 import ru.tinkoff.tcb.mockingbird.grpc.GrpcExractor.FromDynamicSchema
 import ru.tinkoff.tcb.mockingbird.grpc.GrpcExractor.FromGrpcProtoDefinition
+import ru.tinkoff.tcb.mockingbird.model.GrpcEnumSchema
+import ru.tinkoff.tcb.mockingbird.model.GrpcMessageSchema
+import ru.tinkoff.tcb.mockingbird.model.GrpcProtoDefinition
+import ru.tinkoff.tcb.mockingbird.model.GrpcRootMessage
 
 object MappersSpec extends ZIOSpecDefault {
+  val allTypesInRequests = Set(
+    ".BrandAndModelRequest",
+    ".CarGenRequest",
+    ".CarSearchRequest",
+    ".CarConfigurationsRequest",
+    ".Condition",
+    ".CarPriceRequest",
+    ".PreciseCarPriceRequest",
+    ".PriceRequest",
+    ".MemoRequest",
+    ".MemoRequest.ReqEntry", // <-- It's type of the "req" field
+  )
+
+  val allTypesInNested = Set(
+    ".GetStocksRequest",
+    ".GetStocksResponse",
+    ".GetStocksResponse.StockKinds",
+    ".GetStocksResponse.Stock",
+    ".GetStocksResponse.Stocks",
+  )
+
   override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Mappers suite")(
+      test("Mappers from DynamicSchema to GrpcProtoDefinition") {
+        for {
+          content <- Utils.getProtoDescriptionFromResource("requests.proto")
+          schema          = DynamicSchema.parseFrom(content)
+          protoDefinition = schema.toGrpcProtoDefinition
+        } yield assertTrue(getAllTypes(protoDefinition) == allTypesInRequests)
+      },
       test("Mappers from DynamicSchema to GrpcProtoDefinition and back are consistent") {
-        val managed = ZManaged.acquireReleaseWith(ZIO.attemptBlockingIO(Files.createTempDirectory("temp"))) { path =>
-          ZIO.attemptBlockingIO {
-            val dir = new Directory(path.toFile)
-            dir.deleteRecursively()
-          }.orDie
-        }
-        (for {
-          path <- managed
-          readStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(
-              Files.newInputStream(
-                Paths.get("./mockingbird/src/test/resources/requests.proto")
-              )
-            )
-          }
-          writeStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO {
-              Files.newOutputStream(Paths.get(s"${path.toString}/requests.proto"))
-            }
-          }
-          _ <- ZIO.attemptBlockingIO(writeStream.write(readStream.readAllBytes())).toManaged
-          _ <- ZManaged.succeed {
-            s"protoc --descriptor_set_out=${path.toString}/descriptor.desc --proto_path=${path.toString} requests.proto" !
-          }
-          stream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(new FileInputStream(new File(s"${path.toString}/descriptor.desc")))
-          }
-          content <- ZIO.attemptBlockingIO(stream.readAllBytes()).toManaged
+        for {
+          content <- Utils.getProtoDescriptionFromResource("requests.proto")
           schema               = DynamicSchema.parseFrom(content)
           protoDefinition      = schema.toGrpcProtoDefinition
           protoDefinitionAgain = protoDefinition.toDynamicSchema.toGrpcProtoDefinition
-        } yield assertTrue(protoDefinition == protoDefinitionAgain)).useNow
+        } yield assertTrue(protoDefinition == protoDefinitionAgain)
       },
       test("Mappers from nested DynamicSchema to GrpcProtoDefinition and back are consistent") {
-        val managed = ZManaged.acquireReleaseWith(ZIO.attemptBlockingIO(Files.createTempDirectory("temp"))) { path =>
-          ZIO.attemptBlockingIO {
-            val dir = new Directory(path.toFile)
-            dir.deleteRecursively()
-          }.orDie
-        }
-        (for {
-          path <- managed
-          readStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(
-              Files.newInputStream(
-                Paths.get("./mockingbird/src/test/resources/nested.proto")
-              )
-            )
-          }
-          writeStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO {
-              Files.newOutputStream(Paths.get(s"${path.toString}/nested.proto"))
-            }
-          }
-          _ <- ZIO.attemptBlockingIO(writeStream.write(readStream.readAllBytes())).toManaged
-          _ <- ZManaged.succeed {
-            s"protoc --descriptor_set_out=${path.toString}/nested_descriptor.desc --proto_path=${path.toString} nested.proto" !
-          }
-          stream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(new FileInputStream(new File(s"${path.toString}/nested_descriptor.desc")))
-          }
-          content <- ZIO.attemptBlockingIO(stream.readAllBytes()).toManaged
+        for {
+          content <- Utils.getProtoDescriptionFromResource("nested.proto")
+          schema          = DynamicSchema.parseFrom(content)
+          protoDefinition = schema.toGrpcProtoDefinition
+        } yield assertTrue(getAllTypes(protoDefinition) == allTypesInNested)
+      },
+      test("Mappers from nested DynamicSchema to GrpcProtoDefinition and back are consistent") {
+        for {
+          content <- Utils.getProtoDescriptionFromResource("nested.proto")
           schema               = DynamicSchema.parseFrom(content)
           protoDefinition      = schema.toGrpcProtoDefinition
           protoDefinitionAgain = protoDefinition.toDynamicSchema.toGrpcProtoDefinition
-        } yield assertTrue(protoDefinition == protoDefinitionAgain)).useNow
+        } yield assertTrue(protoDefinition == protoDefinitionAgain)
       }
     )
+
+  def getAllTypes(pd: GrpcProtoDefinition): Set[String] =
+    pd.schemas.flatMap(getAllTypes("")).toSet
+
+  def getAllTypes(packageName: String)(m: GrpcRootMessage): List[String] =
+    m match {
+      case GrpcEnumSchema(name, values) => s"$packageName.$name" :: Nil
+      case GrpcMessageSchema(name, fields, oneofs, nested, nestedEnums) =>
+        val npn = s"$packageName.$name"
+        npn :: nested.getOrElse(Nil).flatMap(getAllTypes(npn)) ::: nestedEnums.getOrElse(Nil).flatMap(getAllTypes(npn))
+    }
 }

--- a/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/ProtoToDescriptorSpec.scala
+++ b/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/ProtoToDescriptorSpec.scala
@@ -1,16 +1,8 @@
 package ru.tinkoff.tcb.protobuf
 
-import java.io.File
-import java.io.FileInputStream
-import java.nio.file.Files
-import java.nio.file.Paths
 import scala.jdk.CollectionConverters.SetHasAsScala
-import scala.language.postfixOps
-import scala.reflect.io.Directory
-import scala.sys.process.*
 
 import com.github.os72.protobuf.dynamic.DynamicSchema
-import zio.managed.*
 import zio.test.*
 
 object ProtoToDescriptorSpec extends ZIOSpecDefault {
@@ -24,71 +16,19 @@ object ProtoToDescriptorSpec extends ZIOSpecDefault {
     "utp.stock_service.v1.GetStocksResponse.Stocks"
   )
 
-  override def spec: Spec[TestEnvironment, Any] =
+  override def spec: Spec[TestEnvironment & Scope, Any] =
     suite("Proto to descriptor")(
       test("DynamicSchema is successfully parsed from proto file") {
-        val managed = ZManaged.acquireReleaseWith(ZIO.attemptBlockingIO(Files.createTempDirectory("temp"))) { path =>
-          ZIO.attemptBlockingIO {
-            val dir = new Directory(path.toFile)
-            dir.deleteRecursively()
-          }.orDie
-        }
-        (for {
-          path <- managed
-          readStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(
-              Files.newInputStream(
-                Paths.get("./mockingbird/src/test/resources/requests.proto")
-              )
-            )
-          }
-          writeStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO {
-              Files.newOutputStream(Paths.get(s"${path.toString}/requests.proto"))
-            }
-          }
-          _ <- ZIO.attemptBlockingIO(writeStream.write(readStream.readAllBytes())).toManaged
-          _ <- ZManaged.succeed {
-            s"protoc --descriptor_set_out=${path.toString}/descriptor.desc --proto_path=${path.toString} requests.proto" !
-          }
-          stream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(new FileInputStream(new File(s"${path.toString}/descriptor.desc")))
-          }
-          content <- ZIO.attemptBlockingIO(stream.readAllBytes()).toManaged
+        for {
+          content <- Utils.getProtoDescriptionFromResource("requests.proto")
           schema = DynamicSchema.parseFrom(content)
-        } yield assertTrue(messageTypes.subsetOf(schema.getMessageTypes.asScala))).useNow
+        } yield assertTrue(messageTypes.subsetOf(schema.getMessageTypes.asScala))
       },
       test("DynamicSchema is successfully parsed from proto file with nested schema") {
-        val managed = ZManaged.acquireReleaseWith(ZIO.attemptBlockingIO(Files.createTempDirectory("temp"))) { path =>
-          ZIO.attemptBlockingIO {
-            val dir = new Directory(path.toFile)
-            dir.deleteRecursively()
-          }.orDie
-        }
-        (for {
-          path <- managed
-          readStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(
-              Files.newInputStream(
-                Paths.get("./mockingbird/src/test/resources/nested.proto")
-              )
-            )
-          }
-          writeStream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO {
-              Files.newOutputStream(Paths.get(s"${path.toString}/nested.proto"))
-            }
-          }
-          _ <- ZIO.attemptBlockingIO(writeStream.write(readStream.readAllBytes())).toManaged
-          _ <- ZManaged.succeed {
-            s"protoc --descriptor_set_out=${path.toString}/nested_descriptor.desc --proto_path=${path.toString} nested.proto" !
-          }
-          stream <- ZManaged.fromAutoCloseable {
-            ZIO.attemptBlockingIO(new FileInputStream(new File(s"${path.toString}/nested_descriptor.desc")))
-          }
-          content <- ZIO.attemptBlockingIO(stream.readAllBytes()).toManaged
+        for {
+          content <- Utils.getProtoDescriptionFromResource("nested.proto")
           schema = DynamicSchema.parseFrom(content)
-        } yield assertTrue(nestedMessageTypes.subsetOf(schema.getMessageTypes.asScala))).useNow
+        } yield assertTrue(nestedMessageTypes.subsetOf(schema.getMessageTypes.asScala))
       }
     )
 }

--- a/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/Utils.scala
+++ b/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/Utils.scala
@@ -1,0 +1,45 @@
+package ru.tinkoff.tcb.protobuf
+
+import java.io.File
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.language.postfixOps
+import scala.reflect.io.Directory
+import scala.sys.process.*
+
+object Utils {
+
+  private def openResource(resources: String) = {
+    val cl = Thread.currentThread().getContextClassLoader()
+    cl.getResourceAsStream(resources)
+  }
+
+  private val tmpPath: RIO[Scope, Path] =
+    ZIO.acquireRelease(ZIO.attemptBlockingIO(Files.createTempDirectory("temp"))) { path =>
+      ZIO.attemptBlockingIO {
+        val dir = new Directory(path.toFile)
+        dir.deleteRecursively()
+      }.orDie
+    }
+
+  def getProtoDescriptionFromResource(protoFile: String): RIO[Scope, Array[Byte]] =
+    for {
+      path       <- tmpPath
+      readStream <- ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(openResource(protoFile)))
+      writeStream <- ZIO.fromAutoCloseable {
+        ZIO.attemptBlockingIO {
+          Files.newOutputStream(Paths.get(s"${path.toString}/requests.proto"))
+        }
+      }
+      _ <- ZIO.attemptBlockingIO(writeStream.write(readStream.readAllBytes()))
+      _ <- ZIO.attemptBlockingIO {
+        s"protoc --descriptor_set_out=${path.toString}/descriptor.desc --proto_path=${path.toString} requests.proto" !
+      }
+      stream <- ZIO.fromAutoCloseable {
+        ZIO.attemptBlockingIO(new FileInputStream(new File(s"${path.toString}/descriptor.desc")))
+      }
+      content <- ZIO.attemptBlockingIO(stream.readAllBytes())
+    } yield content
+}


### PR DESCRIPTION
### Problem

Calling of gRPC stub fails if the stub contains proto-scheme with nested enum. Regardless of whether message with the nested enum is used or not.

### Steps to reproduce bugs

The following proto-file occurs the problem.

```proto
syntax = "proto3";
                                                                    
message Request {
    string text = 1;
}

message Response {
    enum Code {
      OK = 0;
      FAIL = 1;
    } 
    optional Code code = 1;
}                  
                                                                              
service Service { 
    rpc Call (Request) returns (Response);
}
```

Creating service:
```
curl -X POST -d '{"suffix":"first", "name":"first"}' http://localhost:8228/api/internal/mockingbird/v2/service
```

Creating a stub using the prototype above:
```
curl -i -X POST localhost:8228/api/internal/mockingbird/v2/grpcStub -d \
'{
  "name": "GRPC ***",
  "labels": [],
  "scope": "persistent",
  "methodName": "Service/Call",
  "requestCodecs": "c3ludGF4ID0gInByb3RvMyI7CgptZXNzYWdlIFJlcXVlc3QgewogICAgc3RyaW5nIHRleHQgPSAxOwp9CgptZXNzYWdlIFJlc3BvbnNlIHsKICAgIGVudW0gQ29kZSB7CiAgICAgIE9LID0gMDsKICAgICAgRkFJTCA9IDE7CiAgICB9CiAgICBvcHRpb25hbCBDb2RlIGNvZGUgPSAxOwp9CgpzZXJ2aWNlIFNlcnZpY2UgewogICAgcnBjIENhbGwgKFJlcXVlc3QpIHJldHVybnMgKFJlc3BvbnNlKTsKfQo=",
  "requestClass": "Request",
  "requestPredicates": {},
  "responseCodecs": "c3ludGF4ID0gInByb3RvMyI7CgptZXNzYWdlIFJlcXVlc3QgewogICAgc3RyaW5nIHRleHQgPSAxOwp9CgptZXNzYWdlIFJlc3BvbnNlIHsKICAgIGVudW0gQ29kZSB7CiAgICAgIE9LID0gMDsKICAgICAgRkFJTCA9IDE7CiAgICB9CiAgICBvcHRpb25hbCBDb2RlIGNvZGUgPSAxOwp9CgpzZXJ2aWNlIFNlcnZpY2UgewogICAgcnBjIENhbGwgKFJlcXVlc3QpIHJldHVybnMgKFJlc3BvbnNlKTsKfQo=",
  "responseClass": "Response",
  "response": {
    "mode": "fill",
    "data": {
      "code": "OK"
    }
  },
  "state": null,
  "seed": null,
  "service": "first"
}' \

```

Calling the stub:

```
grpcurl \
  -proto bad.proto \
  -d '{
  "text": "qwe123"
}' \
  -plaintext localhost:9000 \
  'Service/Call'

```

The expected result of this call, it is successful and returns `{ "code": "OK" }`, but in reality it returns an error.

@mockingbird/maintainers
