### PR TITLE
Fix gRPC stub validation

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcStub.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/GrpcStub.scala
@@ -78,11 +78,12 @@ object GrpcStub {
       case Right(fieldName) =>
         for {
           fs <- fields.get
+          pkgPrefix = definition.`package`.map(p => s".$p.").getOrElse(".")
           field <- ZIO.getOrFailWith(ValidationError(Vector(s"Field $fieldName not found")))(fs.find(_.name == fieldName))
           _ <-
             if (primitiveTypes.values.exists(_ == field.typeName)) fields.set(List.empty)
             else
-              definition.schemas.find(_.name == field.typeName) match {
+              definition.schemas.find(_.name == field.typeName.stripPrefix(pkgPrefix)) match {
                 case Some(message) =>
                   message match {
                     case GrpcMessageSchema(_, fs, oneofs, _, _) =>


### PR DESCRIPTION
The validation fails if gRPC prerequisites refer to fields with custom types.

### Problem

For example, with the following proto-file:

```
syntax = "proto3";

enum Bar {
  KZERO = 0;
  KONE = 1;
}

message Foo {
  string value = 1;
}

message Request {
    optional Bar bar = 1;
    optional Foo foo = 2;
}

message Response {
    string value = 1;
}

service Service {
    rpc Call (Request) returns (Response);
}
```

Attempt to create gRPC returns an error:

```
curl -i -X POST http://127.0.0.1:8228/api/internal/mockingbird/v2/grpcStub \
  -d '
{
  "name": "GRPC ***",
  "labels": [],
  "scope": "persistent",
  "methodName": "Service/Call",
  "requestCodecs": "c3ludGF4ID0gInByb3RvMyI7CgplbnVtIEJhciB7CiAgS1pFUk8gPSAwOwogIEtPTkUgPSAxOwp9CgptZXNzYWdlIEZvbyB7CiAgc3RyaW5nIHZhbHVlID0gMTsKfQoKbWVzc2FnZSBSZXF1ZXN0IHsKICAgIG9wdGlvbmFsIEJhciBiYXIgPSAxOwogICAgRm9vIGZvbyA9IDI7Cn0KCm1lc3NhZ2UgUmVzcG9uc2UgewogICAgc3RyaW5nIHZhbHVlID0gMTsKfQoKc2VydmljZSBTZXJ2aWNlIHsKICAgIHJwYyBDYWxsIChSZXF1ZXN0KSByZXR1cm5zIChSZXNwb25zZSk7Cn0K",
  "requestClass": "Request",
  "requestPredicates": {
    "bar": {"==": "KONE"},
    "foo.value": {"==": "foo"}
  },
  "responseCodecs": "c3ludGF4ID0gInByb3RvMyI7CgplbnVtIEJhciB7CiAgS1pFUk8gPSAwOwogIEtPTkUgPSAxOwp9CgptZXNzYWdlIEZvbyB7CiAgc3RyaW5nIHZhbHVlID0gMTsKfQoKbWVzc2FnZSBSZXF1ZXN0IHsKICAgIG9wdGlvbmFsIEJhciBiYXIgPSAxOwogICAgRm9vIGZvbyA9IDI7Cn0KCm1lc3NhZ2UgUmVzcG9uc2UgewogICAgc3RyaW5nIHZhbHVlID0gMTsKfQoKc2VydmljZSBTZXJ2aWNlIHsKICAgIHJwYyBDYWxsIChSZXF1ZXN0KSByZXR1cm5zIChSZXNwb25zZSk7Cn0K",
  "responseClass": "Response",
  "response": {
    "mode": "fill",
    "data": {
      "value": "OK: KONE, foo"
    }
  },
  "state": null,
  "seed": null,
  "service": "first"
}
'
```

The error is "Message with type .Bar not found".

@mockingbird/maintainers
