### PR TITLE
Fix reconstruction of DynamicSchema from GrpcRootMessage

### DIFF
--- a/backend/mockingbird/src/test/resources/nested.proto
+++ b/backend/mockingbird/src/test/resources/nested.proto
@@ -23,6 +23,23 @@ message GetStocksResponse {
   message Stocks {
     repeated Stock stocks = 1;
   }
+  message Event {
+    enum Code {
+      C_OK = 0;
+      C_ERROR = 1;
+    }
+    message Data {
+      string value = 1;
+    }
+    message Error {
+      string info = 1;
+    }
+    Code code = 1;
+    oneof payload {
+      Data data = 4;
+      Error error = 100;
+    }
+  }
 }
 
 service StockService {

--- a/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/MappersSpec.scala
+++ b/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/protobuf/MappersSpec.scala
@@ -30,6 +30,10 @@ object MappersSpec extends ZIOSpecDefault {
     ".GetStocksResponse.StockKinds",
     ".GetStocksResponse.Stock",
     ".GetStocksResponse.Stocks",
+    ".GetStocksResponse.Event",
+    ".GetStocksResponse.Event.Code",
+    ".GetStocksResponse.Event.Data",
+    ".GetStocksResponse.Event.Error",
   )
 
   override def spec: Spec[TestEnvironment & Scope, Any] =
@@ -48,13 +52,6 @@ object MappersSpec extends ZIOSpecDefault {
           protoDefinition      = schema.toGrpcProtoDefinition
           protoDefinitionAgain = protoDefinition.toDynamicSchema.toGrpcProtoDefinition
         } yield assertTrue(protoDefinition == protoDefinitionAgain)
-      },
-      test("Mappers from nested DynamicSchema to GrpcProtoDefinition and back are consistent") {
-        for {
-          content <- Utils.getProtoDescriptionFromResource("nested.proto")
-          schema          = DynamicSchema.parseFrom(content)
-          protoDefinition = schema.toGrpcProtoDefinition
-        } yield assertTrue(getAllTypes(protoDefinition) == allTypesInNested)
       },
       test("Mappers from nested DynamicSchema to GrpcProtoDefinition and back are consistent") {
         for {


### PR DESCRIPTION
It failed in case nested GrpcSchemaMessage contained another nested messages or enums.

Also, removed duplicate test.

The `backend/mockingbird/src/test/resources/nested.proto` test data updated for reproducing this problem.

@mockingbird/maintainers
