### PR TITLE
Fix Xpath to get correct equals method

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/xpath/Xpath.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/xpath/Xpath.scala
@@ -15,13 +15,18 @@ import ru.tinkoff.tcb.bson.BsonEncoder
 import ru.tinkoff.tcb.bson.BsonKeyDecoder
 import ru.tinkoff.tcb.bson.BsonKeyEncoder
 
-final case class Xpath(raw: String, toXPathExpr: XPathExpression) {
+/*
+ * toXPathExpr inside extra braces is important. It's exclude this value
+ * from hash and equals method. XPathExpression doesn't have correct equals
+ * method, it is comparable only by reference.
+ */
+final case class Xpath(raw: String)(val toXPathExpr: XPathExpression) {
   override def toString: String = raw
 }
 
 object Xpath {
   def fromString(pathStr: String): Try[Xpath] =
-    Try(xPathFactory.newXPath().compile(pathStr)).map(Xpath(pathStr, _))
+    Try(xPathFactory.newXPath().compile(pathStr)).map(Xpath(pathStr))
 
   def unapply(str: String): Option[Xpath] =
     fromString(str).toOption

--- a/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/xpath/XpathSpec.scala
+++ b/backend/mockingbird/src/test/scala/ru/tinkoff/tcb/xpath/XpathSpec.scala
@@ -1,0 +1,15 @@
+package ru.tinkoff.tcb.xpath
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class XpathSpec extends AnyFunSuite with Matchers {
+
+  test("Xpath equals") {
+    val xp1 = Xpath.fromString("//user/@id")
+    val xp2 = Xpath.fromString("//user/@id")
+
+    xp1 shouldBe xp2
+  }
+
+}


### PR DESCRIPTION
### Problem

One can create multiple equal stubs if body request prerequisite contains xpath.

Stub example:

```
{
  "path": "/alpha/test/request",
  "name": "request",
  "labels": [],
  "method": "POST",
  "scope": "persistent",
  "request": {
    "headers": {},
    "query": {},
    "body": {
      "/Envelope/Body/loadData/data/request[@optype='02']": {
        "exists": true
      }
    },
    "extractors": {},
    "inlineCData": true,
    "mode": "xpath"
  },
  "response": {
    "code": 200,
    "headers": {
      "Content-Type": "application/xml"
    },
    "body": "<?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"><soapenv:Body></soapenv:Body></soapenv:Envelope>",
    "delay": null,
    "mode": "xml"
  }
}
```

### Solution

The problem is the equals method of XPathExpression return false for two equal instances. The solution is exclude  the field toXPathExpr from the equals method of Xpath type. 

@mockingbird/maintainers
