### PR TITLE
Update options of outgoing requests, allow update server options of Vert.x

### DIFF
--- a/backend/edsl/src/main/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/package.scala
+++ b/backend/edsl/src/main/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/package.scala
@@ -1,6 +1,7 @@
 package ru.tinkoff.tcb.mockingbird.edsl
 
 import sttp.client4.*
+import sttp.client4.DuplicateHeaderBehavior
 import sttp.model.Uri
 import sttp.model.Uri.QuerySegment
 
@@ -16,7 +17,7 @@ package object interpreter {
   def buildRequest(host: Uri, m: HttpRequest): Request[String] = {
     val initialRequest = emptyRequest.response(asStringAlways)
     var req            = m.body.fold(initialRequest)(initialRequest.body)
-    req = m.headers.foldLeft(req) { case (r, (k, v)) => r.header(k, v, replaceExisting = true) }
+    req = m.headers.foldLeft(req) { case (r, (k, v)) => r.header(k, v, DuplicateHeaderBehavior.Replace) }
     val url = makeUri(host, m)
     m.method match {
       case Delete => req.delete(url)

--- a/backend/edsl/src/test/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/AsyncScalaTestSuiteTest.scala
+++ b/backend/edsl/src/test/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/AsyncScalaTestSuiteTest.scala
@@ -9,11 +9,13 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.Informer
 import org.scalatest.matchers.should.Matchers
 import sttp.client4.*
+import sttp.client4.Response
 import sttp.client4.httpclient.HttpClientFutureBackend
 import sttp.client4.testing.WebSocketBackendStub
 import sttp.model.Header
 import sttp.model.MediaType
 import sttp.model.Method.*
+import sttp.model.RequestMetadata
 import sttp.model.StatusCode
 import sttp.model.Uri
 
@@ -67,7 +69,14 @@ class AsyncScalaTestSuiteTest extends AsyncScalaTestSuite with Matchers with Asy
           if uri == uri"http://some.domain.com:8090/api/handler?service=world"
             && hs.exists(h => h.name == "x-token" && h.value == "asd5453qwe")
             && hs.exists(h => h.name == "Content-Type" && h.value == "application/json") =>
-        Response(body = "got request", code = StatusCode.Ok)
+        new Response[String](
+          body = "got request",
+          code = StatusCode.Ok,
+          statusText = "",
+          headers = Seq.empty,
+          history = Nil,
+          request = RequestMetadata(POST, uri, hs),
+        )
     }
 
     val example = eset.sendHttp(method, path, body.some, headers, query)
@@ -81,11 +90,13 @@ class AsyncScalaTestSuiteTest extends AsyncScalaTestSuite with Matchers with Asy
   test("checkHttp checks code of response") {
     sttpbackend_ = HttpClientFutureBackend.stub().whenRequestMatches(_ => true).thenRespondOk()
 
-    val sttpResp = Response(
+    val sttpResp = new Response(
       body = "got request",
       code = StatusCode.InternalServerError,
       statusText = "",
       headers = Seq.empty,
+      history = Nil,
+      request = RequestMetadata(GET, uri"https://host.domain", Seq.empty)
     )
 
     val example = eset.checkHttp(
@@ -105,11 +116,13 @@ class AsyncScalaTestSuiteTest extends AsyncScalaTestSuite with Matchers with Asy
   test("checkHttp checks body of response") {
     sttpbackend_ = HttpClientFutureBackend.stub().whenRequestMatches(_ => true).thenRespondOk()
 
-    val sttpResp = Response(
+    val sttpResp = new Response(
       body = "got request",
       code = StatusCode.Ok,
       statusText = "",
       headers = Seq.empty,
+      history = Nil,
+      request = RequestMetadata(GET, uri"https://host.domain", Seq.empty)
     )
 
     val example = eset.checkHttp(
@@ -129,11 +142,13 @@ class AsyncScalaTestSuiteTest extends AsyncScalaTestSuite with Matchers with Asy
   test("checkHttp checks headers of response") {
     sttpbackend_ = HttpClientFutureBackend.stub().whenRequestMatches(_ => true).thenRespondOk()
 
-    val sttpResp = Response(
+    val sttpResp = new Response(
       body = "{}",
       code = StatusCode.Ok,
       statusText = "",
       headers = Seq(Header.contentType(MediaType.TextPlain)),
+      history = Nil,
+      request = RequestMetadata(GET, uri"https://host.domain", Seq.empty)
     )
 
     val example = eset.checkHttp(

--- a/backend/edsl/src/test/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/AsyncScalaTestSuiteWholeTest.scala
+++ b/backend/edsl/src/test/scala/ru/tinkoff/tcb/mockingbird/edsl/interpreter/AsyncScalaTestSuiteWholeTest.scala
@@ -14,6 +14,7 @@ import sttp.client4.testing.WebSocketBackendStub
 import sttp.model.Header
 import sttp.model.MediaType
 import sttp.model.Method.*
+import sttp.model.RequestMetadata
 import sttp.model.StatusCode
 import sttp.model.Uri
 
@@ -61,14 +62,20 @@ class AsyncScalaTestSuiteWholeTest
         req.headers.exists(h => h.name == "X-CSRF-TOKEN" && h.value == "unEENxJqSLS02rji2GjcKzNLc0C0ySlWih9hSxwn")
       }
       .thenRespond(
-        Response(
+        new Response(
           body = """{
                    |  "fact" : "There are approximately 100 breeds of cat.",
                    |  "length" : 42.0
                    |}""".stripMargin,
           code = StatusCode.Ok,
           statusText = "",
-          headers = Seq(Header.contentType(MediaType.ApplicationJson))
+          headers = Seq(Header.contentType(MediaType.ApplicationJson)),
+          history = Nil,
+          request = RequestMetadata(
+            GET,
+            uri"https://localhost.example:9977/fact",
+            Seq(Header("X-CSRF-TOKEN", "unEENxJqSLS02rji2GjcKzNLc0C0ySlWih9hSxwn"))
+          ),
         )
       )
   }

--- a/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/Mockingbird.scala
+++ b/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/Mockingbird.scala
@@ -31,6 +31,7 @@ import ru.tinkoff.tcb.mockingbird.api.Tracing
 import ru.tinkoff.tcb.mockingbird.api.UIHttp
 import ru.tinkoff.tcb.mockingbird.api.WLD
 import ru.tinkoff.tcb.mockingbird.api.WebAPI
+import ru.tinkoff.tcb.mockingbird.config.HttpVersion
 import ru.tinkoff.tcb.mockingbird.config.MockingbirdConfiguration
 import ru.tinkoff.tcb.mockingbird.config.MongoCollections
 import ru.tinkoff.tcb.mockingbird.config.MongoConfig
@@ -133,6 +134,10 @@ object Mockingbird extends scala.App {
             }
             httpClient = HttpClient
               .newBuilder()
+              .version(pc.httpVersion match {
+                case HttpVersion.HTTP_1_1 => HttpClient.Version.HTTP_1_1
+                case HttpVersion.HTTP_2   => HttpClient.Version.HTTP_2
+              })
               .connectTimeout(sttpSettings.connectionTimeout.toJava)
               .pipe(b => sttpSettings.proxy.fold(b)(conf => b.proxy(conf.asJavaProxySelector)))
               .sslContext(sslContext)

--- a/backend/mockingbird/src/main/resources/application.conf
+++ b/backend/mockingbird/src/main/resources/application.conf
@@ -22,6 +22,10 @@ ru.tinkoff.tcb {
       "http://localhost:3000",
       "http://localhost:8228"
     ]
+    vertx {
+      maxFormAttributeSize = 262144
+      compressionSupported = true
+    }
   }
 
   proxy {
@@ -29,6 +33,8 @@ ru.tinkoff.tcb {
     excludedResponseHeaders = []
     insecureHosts = []
     logOutgoingRequests = false
+    disableAutoDecompressForRaw = true
+    httpVersion = HTTP_1_1
   }
 
   event {

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/utils/xttp/package.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/utils/xttp/package.scala
@@ -1,12 +1,13 @@
 package ru.tinkoff.tcb.utils
 
+import sttp.client4.DuplicateHeaderBehavior
 import sttp.client4.PartialRequest
 
 package object xttp {
   implicit class PartialRequestTXtras[T](private val rqt: PartialRequest[T]) extends AnyVal {
     def headersReplacing(hs: Map[String, String]): PartialRequest[T] =
       hs.foldLeft(rqt) { case (request, (key, value)) =>
-        request.header(key, value, true)
+        request.header(key, value, DuplicateHeaderBehavior.Replace)
       }
   }
 }

--- a/backend/project/Versions.scala
+++ b/backend/project/Versions.scala
@@ -6,6 +6,6 @@ object Versions {
   val graalvm          = "22.3.0"
   val micrometer       = "1.8.5"
   val glass            = "0.2.1"
-  val sttp             = "4.0.0-M9"
+  val sttp             = "4.0.0-M13"
   val zio              = "2.0.19"
 }

--- a/configuration.md
+++ b/configuration.md
@@ -11,7 +11,11 @@ Mockingbird is configured via the secrets.conf file, which has the following str
         "http://localhost:3000",
         ...
       ],
-      "healthCheckRoute": "/ready"
+      "healthCheckRoute": "/ready",
+      "vertx": {
+        "maxFormAttributeSize": 262144,
+        "compressionSupported": true
+      }
     },
     "security": {
       "secret": ".."
@@ -24,6 +28,8 @@ Mockingbird is configured via the secrets.conf file, which has the following str
       "excludedResponseHeaders": [..],
       "insecureHosts": [..],
       "logOutgoingRequests": false,
+      "disableAutoDecompressForRaw": "true",
+      "httpVersion": "HTTP_1_1",
       "proxyServer": {
         "type": "http" | "socks",
         "type": "..",
@@ -50,6 +56,8 @@ Mockingbird is configured via the secrets.conf file, which has the following str
 This section specifies origins for CORS. These settings affect the functionality of UI Mockingbird as well as swagger-ui.
 
 healthCheckRoute - an optional parameter that allows configuring an endpoint always returning 200 OK, useful for health checks.
+
+Inside the vertx section, one can set up any [HTTP server options of Vert.x](https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html)
 
 ### Security Section
 
@@ -94,7 +102,9 @@ Example of a typical configuration:
       "insecureHosts": [
         "some.host"
       ],
-      "logOutgoingRequests": false
+      "logOutgoingRequests": false,
+      "disableAutoDecompressForRaw": "true",
+      "httpVersion": "HTTP_1_1"
     }
   }
 }
@@ -103,6 +113,10 @@ Example of a typical configuration:
 In the insecureHosts field, you can specify a list of hosts for which certificate validation will not be performed. This can be useful for deployments within internal infrastructure.
 
 The logOutgoingRequests flag allows enabling logging of requests to the remote server when the HTTP mock is operating in proxy mode. The request is logged in the form of a curl command with headers and request body.
+
+The disableAutoDecompressForRaw flag allow disabling automatic decompression of response for proxy stub with mode `proxy`.
+
+The httpVersion allows to configure the desired HTTP protocol version for outgoing requests, possible values: HTTP_1_1 or HTTP_2.
 
 Also, in this section, you can specify proxy server settings. These settings affect ALL HTTP requests made by Mockingbird, including:
 

--- a/configuration_ru.md
+++ b/configuration_ru.md
@@ -11,7 +11,11 @@ Mockingbird конфигурируется посредством файла sec
         "http://localhost:3000",
         ...
       ],
-      "healthCheckRoute": "/ready"
+      "healthCheckRoute": "/ready",
+      "vertx": {
+        "maxFormAttributeSize": 262144,
+        "compressionSupported": true
+      }
     },
     "security": {
       "secret": ".."
@@ -24,6 +28,8 @@ Mockingbird конфигурируется посредством файла sec
       "excludedResponseHeaders": [..],
       "insecureHosts": [..],
       "logOutgoingRequests": false,
+      "disableAutoDecompressForRaw": "true",
+      "httpVersion": "HTTP_1_1",
       "proxyServer": {
         "type": "http" | "socks",
         "type": "..",
@@ -50,6 +56,8 @@ Mockingbird конфигурируется посредством файла sec
 Здесь указыватся ориджены для CORS. Эти настройки влияют на работоспособность UI Mockingbird, а также swagger-ui
 
 healthCheckRoute - необязательный параметр, позволяет настроить эндпоинт, всегда отдающий 200 OK, полезно для healthcheck
+
+Внутрии секции vertx можно задать [параметры для сервера Vert.x](https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerOptions.html).
 
 ### Секция security
 
@@ -94,7 +102,9 @@ healthCheckRoute - необязательный параметр, позволя
       "insecureHosts": [
         "some.host"
       ],
-      "logOutgoingRequests": false
+      "logOutgoingRequests": false,
+      "disableAutoDecompressForRaw": "true",
+      "httpVersion": "HTTP_1_1"
     }
   }
 }
@@ -104,6 +114,10 @@ healthCheckRoute - необязательный параметр, позволя
 для случаев развёртывания во внутренней инфраструктуре.
 
 Флаг logOutgoingRequests позволяет включить логирование запросов к удаленному серверу, когда http заглушка работет в режиме прокси. Запрос пишется в лог в виде команды curl с заголовками и телом запроса.
+
+Флаг disableAutoDecompressForRaw отключает автоматическую декомпрессию ответа для заглушек с режимом `proxy`.
+
+Параметр httpVersion отвечает за версию протокола исопльзуемого для исходящих HTTP запросов, может принимать значения `HTTP_1_1` или `HTTP_2`.
 
 Так-же в этой секции можно указать настройки прокси сервера. Эти настройки влияют на ВСЕ http запросы, которые делаем mockingbird, т.е.:
 - запросы к внешнему серверу с proxy моках


### PR DESCRIPTION
* Switch to HTTP 1.1 for outgoing requests instead of HTTP 2. There are problems with Rabbit MQ REST API when using HTTP 2. It doesn't handle requests for protocol version upgrades correctly.

* Fix headers of proxy requests. The modes json-proxy and xml-proxy modify answer, so passing headers Content-Encoding and Content-Length from the original response makes the response of the stub is invalid.

* Disable decompressing of response for the mode proxy. Decompression without excluding the content-encoding header produces an incorrect response.  Also, an expectation from the mode proxy is the response is returned without modification, but decompression breaks the expectation.

* Up version of sttp client, because previous version wrong handles Content-Type and Content-Length headers if they are written in low-case. Some clients send these headers in low-case. Fix in sttp repository: https://github.com/softwaremill/sttp/pull/2135.

@mockingbird/maintainers
