### PR TITLE
Keep original request body as Array[Byte]

### DIFF
--- a/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/admin/package.scala
+++ b/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/admin/package.scala
@@ -66,10 +66,9 @@ package object admin {
       .summary("Test HTTP stub resolution")
       .in(execInput)
       .in(
-        binaryBody(RawBodyType.ByteArrayBody)[Option[String]]
-          .map[RequestBody]((_: Option[String]).fold[RequestBody](AbsentRequestBody)(SimpleRequestBody(_)))(
-            SimpleRequestBody.subset.getOption(_).map(_.value)
-          )
+        byteArrayBody.map[RequestBody]((b: Array[Byte]) => if (b.isEmpty) AbsentRequestBody else SimpleRequestBody(b))(
+          SimpleRequestBody.subset.getOption(_).map(_.binary).getOrElse(Array.empty)
+        )
       )
       .out(jsonBody[SID[HttpStub]])
 

--- a/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/exec/package.scala
+++ b/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/exec/package.scala
@@ -48,10 +48,9 @@ package object exec {
     baseEndpoint
       .in(execInput)
       .in(
-        binaryBody(RawBodyType.ByteArrayBody)[Option[String]]
-          .map[RequestBody]((_: Option[String]).fold[RequestBody](AbsentRequestBody)(SimpleRequestBody(_)))(
-            SimpleRequestBody.subset.getOption(_).map(_.value)
-          )
+        byteArrayBody.map[RequestBody]((b: Array[Byte]) => if (b.isEmpty) AbsentRequestBody else SimpleRequestBody(b))(
+          SimpleRequestBody.subset.getOption(_).map(_.binary).getOrElse(Array.empty)
+        )
       )
       .out(headers)
       .out(statusCode)

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/RequestBody.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/model/RequestBody.scala
@@ -19,7 +19,9 @@ case object AbsentRequestBody extends RequestBody {
   implicit val absentRequestBodyLoggable: Loggable[AbsentRequestBody.type] = Loggable.empty[AbsentRequestBody.type]
 }
 
-final case class SimpleRequestBody(value: String) extends RequestBody
+final case class SimpleRequestBody(binary: Array[Byte]) extends RequestBody {
+  val value: String = new String(binary)
+}
 object SimpleRequestBody {
   final val subset: Subset[RequestBody, SimpleRequestBody] = GenSubset[RequestBody, SimpleRequestBody]
 


### PR DESCRIPTION
Keep the original body request as an Array[Byte]. It's necessary for the mode proxy, because if the body is binary data, converting to string makes the body is invalid.

@mockingbird/maintainers
