### PR TITLE
Fix gRPC method name generation for proxy request

### DIFF
--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcRequestHandler.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/grpc/GrpcRequestHandler.scala
@@ -89,7 +89,7 @@ class GrpcRequestHandlerImpl(
           result <- ClientCalls
             .unaryCall(
               channel,
-              Method.byteMethod(context.methodDescriptor.getServiceName, context.methodDescriptor.getFullMethodName),
+              Method.byteMethod(context.methodDescriptor.getServiceName, context.methodDescriptor.getBareMethodName),
               CallOptions.DEFAULT,
               context.metadata,
               bytes


### PR DESCRIPTION
### Problem

When one makes gRPC call `ServiceName/MethodName` of proxy stub, Mockingbird makes proxy call to  `ServiceName/ServiceName`.


@mockingbird/maintainers
