### PR TITLE
Fix query params handling

### DIFF
--- a/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/PublicHttp.scala
+++ b/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/PublicHttp.scala
@@ -85,7 +85,7 @@ final class PublicHttp(handler: PublicApiHandler) {
       method: HttpMethod,
       path: String,
       headers: Map[String, String],
-      query: Map[String, String],
+      query: Seq[(String, Seq[String])],
       body: RequestBody
   ): ZIO[WLD, Throwable, (List[Header], StatusCode, HttpStubResponse)] =
     handler

--- a/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/input/package.scala
+++ b/backend/mockingbird-api/src/main/scala/ru/tinkoff/tcb/mockingbird/api/input/package.scala
@@ -9,8 +9,8 @@ import ru.tinkoff.tcb.mockingbird.model.HttpMethod
 import ru.tinkoff.tcb.mockingbird.model.RequestBody
 
 package object input {
-  private[api] type ExecInput  = (HttpMethod, String, Map[String, String], Map[String, String])
-  private[api] type ExecInputB = (HttpMethod, String, Map[String, String], Map[String, String], RequestBody)
+  private[api] type ExecInput  = (HttpMethod, String, Map[String, String], Seq[(String, Seq[String])])
+  private[api] type ExecInputB = (HttpMethod, String, Map[String, String], Seq[(String, Seq[String])], RequestBody)
 
   private[api] val execInput: EndpointInput[ExecInput] =
     extractFromRequest(_.method)
@@ -20,7 +20,5 @@ package object input {
         extractFromRequest(_.headers)
           .map(_.map(h => h.name -> h.value).to(Map))(_.map { case (name, value) => Header(name, value) }.to(Seq))
       )
-      .and(
-        queryParams.map(_.toMap)(QueryParams.fromMap)
-      )
+      .and(queryParams.map(_.ps)(QueryParams(_)))
 }

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/AdminApiHandler.scala
@@ -6,8 +6,6 @@ import eu.timepit.refined.*
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.*
 import eu.timepit.refined.numeric.*
-import io.circe.Json
-import io.circe.parser.parse
 import io.scalaland.chimney.dsl.*
 import kantan.xpath.*
 import kantan.xpath.implicits.*
@@ -191,10 +189,10 @@ final class AdminApiHandler(
       method: HttpMethod,
       path: String,
       headers: Map[String, String],
-      query: Map[String, String],
+      query: Seq[(String, Seq[String])],
       body: RequestBody
   ): RIO[WLD, SID[HttpStub]] = {
-    val queryObject = Json.fromFields(query.view.mapValues(s => parse(s).getOrElse(Json.fromString(s))))
+    val queryObject = queryParamsToJsonObject(query)
     val f           = stubResolver.findStubAndState(method, path, headers, queryObject, body) _
 
     for {

--- a/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/package.scala
+++ b/backend/mockingbird/src/main/scala/ru/tinkoff/tcb/mockingbird/api/package.scala
@@ -1,6 +1,8 @@
 package ru.tinkoff.tcb.mockingbird
 
+import io.circe.Json
 import io.circe.literal.*
+import io.circe.parser.parse
 
 package object api {
   /*
@@ -10,4 +12,15 @@ package object api {
 
   def mkErrorResponse(message: String): String =
     json"""{"error": $message}""".noSpaces
+
+  def queryParamsToJsonObject(query: Seq[(String, Seq[String])]): Json =
+    Json.fromFields(
+      query.map { case (k, vs) =>
+        val js = vs.map(s => parse(s).getOrElse(Json.fromString(s))) match {
+          case Seq(x) => x
+          case xs     => Json.arr(xs: _*)
+        }
+        k -> js
+      }
+    )
 }


### PR DESCRIPTION
### Problem

Sometimes one can meet query parameter without a value, just a key, for example `http://host.domain/app/srvice?wsdl`. Mockingbird didn't let to add a condition for checking existing such query parameters. Also, it didn't pass them with proxy request.

Another problem was multiple values of one query parameter, e.g. `http://host.domain?a=1&a=2`. Mockingbird took only the last value and dropped all others.

@mockingbird/maintainers
